### PR TITLE
Fixed dropzone being too small on firefox

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,10 @@ function App() {
         window.URL.revokeObjectURL(link.href);
         return "Downloaded";
       },
-      error: "Something went wrong 😔",
+      error: () => {
+        playError();
+        return "Something went wrong 😔";
+      },
     });
     return response.message;
   };
@@ -41,6 +44,7 @@ function App() {
     try {
       await validateZip(archive);
     } catch (reason) {
+      playError();
       if (typeof reason === "string") {
         toast.error(reason);
       } else {

--- a/src/components/Flask/index.tsx
+++ b/src/components/Flask/index.tsx
@@ -43,11 +43,9 @@ const DropZone = tw.div<DropZoneProps>`
 `;
 
 const FileInput = tw.input`
-  absolute
-  top-0
-  right-0
-  left-0
-  bottom-0
+  relative
+  h-full
+  w-full
   opacity-0
 `;
 


### PR DESCRIPTION
On Firefox the dropzone was too small which resulted in it working only on the left side of the screen - which was confusing since the dropzone is invisible until it detects a file. This patch fixes the issue by adjusing styling of the `<input>` element from
```tailwindcss
  absolute
  top-0
  right-0
  left-0
  bottom-0
```
to
```tailwindcss
  relative
  h-full
  w-full
```
---
Bonus bugfix: failure sound didn't play for some errors.
