### PR TITLE
Added MediaConverters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "use-sound": "^4.0.1"
       },
       "devDependencies": {
+        "@types/node": "^20.8.9",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
@@ -788,6 +789,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
       "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.9.tgz",
+      "integrity": "sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.6",
@@ -2490,9 +2500,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.30",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
-      "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
         {
@@ -3169,6 +3179,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "use-sound": "^4.0.1"
   },
   "devDependencies": {
+    "@types/node": "^20.8.9",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,10 @@ import errorSfx from "@assets/sound/error.ogg";
 import useSound from "use-sound";
 import ImageMediaConverter from "./services/converters/ImageMediaConverter";
 import JSZip from "jszip";
-import { MediaFile } from "./services/converters/MediaConverter";
+import MediaConverter, {
+  MediaFile,
+} from "./services/converters/MediaConverter";
+import FontMediaConverter from "./services/converters/FontMediaConverter";
 
 const downloadBlob = (blob: Blob) => {
   const link = document.createElement("a");
@@ -23,10 +26,14 @@ const downloadBlob = (blob: Blob) => {
 const isImageFile = (file: File): boolean =>
   file.type === "image/png" || file.type === "image/jpeg";
 
+const isFontFile = (file: File): boolean =>
+  file.name.endsWith(".ttf") || file.name.endsWith(".otf");
+
 function App() {
   const [playSuccess] = useSound(successSfx);
   const [playError] = useSound(errorSfx);
   const imageConverter = new ImageMediaConverter("/convert/t3x");
+  const fontConverter = new FontMediaConverter("/convert/bcfnt");
 
   const handleUploadSuccess = (response: BundlerResponse) => {
     toast.promise(response.file as Promise<Blob>, {
@@ -50,9 +57,17 @@ function App() {
   };
 
   const handleUpload = async (files: File[]) => {
+    let converter: MediaConverter | undefined;
+    console.log(files[0].type);
     if (isImageFile(files[0])) {
+      converter = imageConverter;
+    } else if (isFontFile(files[0])) {
+      converter = fontConverter;
+    }
+    console.log(converter);
+    if (converter !== undefined) {
       toast.promise(
-        imageConverter.convert(
+        converter.convert(
           files.map((file: File) => ({ filepath: file.name, data: file }))
         ),
         {
@@ -118,7 +133,7 @@ function App() {
       />
       <Flask
         uploadHandler={handleUpload}
-        accept={[".zip", ".png", ".jpg", ".jpeg"]}
+        accept={[".zip", ".png", ".jpg", ".jpeg", ".otf", ".ttf"]}
       />
       <Footer />
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,13 +58,11 @@ function App() {
 
   const handleUpload = async (files: File[]) => {
     let converter: MediaConverter | undefined;
-    console.log(files[0].type);
     if (isImageFile(files[0])) {
       converter = imageConverter;
     } else if (isFontFile(files[0])) {
       converter = fontConverter;
     }
-    console.log(converter);
     if (converter !== undefined) {
       toast.promise(
         converter.convert(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,21 +8,32 @@ import errorSfx from "@assets/sound/error.ogg";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore Ignore broken library typings
 import useSound from "use-sound";
+import ImageMediaConverter from "./services/converters/ImageMediaConverter";
+import JSZip from "jszip";
+import { MediaFile } from "./services/converters/MediaConverter";
+
+const downloadBlob = (blob: Blob) => {
+  const link = document.createElement("a");
+  link.href = URL.createObjectURL(blob);
+  link.download = `bundle-${+new Date()}.zip`;
+  link.click();
+  window.URL.revokeObjectURL(link.href);
+};
+
+const isImageFile = (file: File): boolean =>
+  file.type === "image/png" || file.type === "image/jpeg";
 
 function App() {
   const [playSuccess] = useSound(successSfx);
   const [playError] = useSound(errorSfx);
+  const imageConverter = new ImageMediaConverter("/convert/t3x");
 
   const handleUploadSuccess = (response: BundlerResponse) => {
     toast.promise(response.file as Promise<Blob>, {
       loading: "Downloading",
       success: (blob) => {
         playSuccess();
-        const link = document.createElement("a");
-        link.href = URL.createObjectURL(blob);
-        link.download = `bundle-${+new Date()}.zip`;
-        link.click();
-        window.URL.revokeObjectURL(link.href);
+        downloadBlob(blob);
         return "Downloaded";
       },
       error: () => {
@@ -39,6 +50,29 @@ function App() {
   };
 
   const handleUpload = async (files: File[]) => {
+    if (isImageFile(files[0])) {
+      toast.promise(
+        imageConverter.convert(
+          files.map((file: File) => ({ filepath: file.name, data: file }))
+        ),
+        {
+          loading: "Uploading",
+          success: (files: MediaFile[]) => {
+            playSuccess();
+            const zip = new JSZip();
+            for (const file of files) {
+              zip.file(file.filepath, file.data);
+            }
+            zip
+              .generateAsync({ type: "blob" })
+              .then((blob) => downloadBlob(blob));
+            return "Downloaded";
+          },
+          error: handleUploadError,
+        }
+      );
+      return;
+    }
     const archive = files[0];
 
     try {
@@ -82,7 +116,10 @@ function App() {
           },
         }}
       />
-      <Flask uploadHandler={handleUpload} />
+      <Flask
+        uploadHandler={handleUpload}
+        accept={[".zip", ".png", ".jpg", ".jpeg"]}
+      />
       <Footer />
     </>
   );

--- a/src/components/Flask/index.tsx
+++ b/src/components/Flask/index.tsx
@@ -49,9 +49,12 @@ const FileInput = tw.input`
   opacity-0
 `;
 
-type FlaskProps = { uploadHandler: (a: File[]) => void };
+type FlaskProps = {
+  uploadHandler: (a: File[]) => void;
+  accept: string | string[];
+};
 
-function Flask({ uploadHandler }: FlaskProps) {
+function Flask({ uploadHandler, accept }: FlaskProps) {
   const [isDragActive, setDragActive] = useState<boolean>(false);
 
   const handleDragEnter = () => {
@@ -76,6 +79,10 @@ function Flask({ uploadHandler }: FlaskProps) {
     fileEvent.target.value = "";
   };
 
+  if (Array.isArray(accept)) {
+    accept = accept.reduce((a, b) => `${a},${b}`);
+  }
+
   return (
     <FlaskContainer>
       <FlaskImage src={Logo} />
@@ -83,7 +90,7 @@ function Flask({ uploadHandler }: FlaskProps) {
         <FileInput
           type="file"
           title=""
-          accept=".zip"
+          accept={accept}
           onDragEnter={handleDragEnter}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}

--- a/src/services/converters/FontMediaConverter.ts
+++ b/src/services/converters/FontMediaConverter.ts
@@ -1,0 +1,22 @@
+import MediaConverter, { MediaFile } from "./MediaConverter";
+
+export default class FontMediaConverter extends MediaConverter {
+  async convert(files: MediaFile[]): Promise<MediaFile[]> {
+    const body = new FormData();
+
+    for (const file of files) {
+      body.append(file.filepath, file.data);
+    }
+
+    const url = `${process.env.BASE_URL}${this.path}`;
+    const request = fetch(url, {
+      method: "POST",
+      body,
+    });
+    const response = await (await request).json();
+    if (!this.isMediaResponse(response)) {
+      throw Error("Invalid Response");
+    }
+    return this.responseToMediaFileArray(response, "font/bcfnt");
+  }
+}

--- a/src/services/converters/ImageMediaConverter.ts
+++ b/src/services/converters/ImageMediaConverter.ts
@@ -19,6 +19,7 @@ export default class ImageMediaConverter extends MediaConverter {
     });
   }
   async convert(files: MediaFile[]): Promise<MediaFile[]> {
+    const body = new FormData();
     for (const file of files) {
       await this.checkImage(file.data).then((isValid: boolean) => {
         if (!isValid) {
@@ -28,14 +29,14 @@ export default class ImageMediaConverter extends MediaConverter {
         }
       });
     }
-
-    const body = new FormData();
-    const url = `${import.meta.env.BASE_URL}${this.path}`;
+    const url = `${process.env.BASE_URL}${this.path}`;
+    console.log(url);
     const request = fetch(url, {
       method: "POST",
       body,
     });
     const response = await (await request).json();
+    console.log("fetched");
     if (!this.isMediaResponse(response)) {
       throw Error("invalid data");
     }

--- a/src/services/converters/ImageMediaConverter.ts
+++ b/src/services/converters/ImageMediaConverter.ts
@@ -11,10 +11,14 @@ export default class ImageMediaConverter extends MediaConverter {
     const body = new FormData();
 
     for (const file of files) {
-      if (!(await this.checkImage(file.data))) {
-        throw Error(`Image ${file.filepath} is too large!`);
-      } else {
-        body.append(file.filepath, file.data);
+      try {
+        if (!(await this.checkImage(file.data))) {
+          throw Error(`Image ${file.filepath} is too large!`);
+        } else {
+          body.append(file.filepath, file.data);
+        }
+      } catch (error) {
+        throw Error(`Image ${file.filepath} is invalid!`);
       }
     }
 

--- a/src/services/converters/ImageMediaConverter.ts
+++ b/src/services/converters/ImageMediaConverter.ts
@@ -29,9 +29,7 @@ export default class ImageMediaConverter extends MediaConverter {
       }
     }
 
-    console.log(body);
     const url = `${process.env.BASE_URL}${this.path}`;
-    console.log(url);
     const request = fetch(url, {
       method: "POST",
       body,

--- a/src/services/converters/ImageMediaConverter.ts
+++ b/src/services/converters/ImageMediaConverter.ts
@@ -20,15 +20,16 @@ export default class ImageMediaConverter extends MediaConverter {
   }
   async convert(files: MediaFile[]): Promise<MediaFile[]> {
     const body = new FormData();
+
     for (const file of files) {
-      await this.checkImage(file.data).then((isValid: boolean) => {
-        if (!isValid) {
-          throw Error("not an image");
-        } else {
-          body.append(file.filepath, file.data);
-        }
-      });
+      if (!(await this.checkImage(file.data))) {
+        throw Error("not an image");
+      } else {
+        body.append(file.filepath, file.data);
+      }
     }
+
+    console.log(body);
     const url = `${process.env.BASE_URL}${this.path}`;
     console.log(url);
     const request = fetch(url, {
@@ -40,6 +41,6 @@ export default class ImageMediaConverter extends MediaConverter {
     if (!this.isMediaResponse(response)) {
       throw Error("invalid data");
     }
-    return this.responseToMediaFileArray(response);
+    return this.responseToMediaFileArray(response, "image/t3x");
   }
 }

--- a/src/services/converters/ImageMediaConverter.ts
+++ b/src/services/converters/ImageMediaConverter.ts
@@ -1,0 +1,44 @@
+import MediaConverter, { MediaFile } from "./MediaConverter";
+
+const MAX_IMAGE_DIM = 1024;
+
+export default class ImageMediaConverter extends MediaConverter {
+  checkImage(file: Blob): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      createImageBitmap(file)
+        .then((image: ImageBitmap) => {
+          if (image.width > MAX_IMAGE_DIM || image.height > MAX_IMAGE_DIM) {
+            resolve(false);
+          } else {
+            resolve(true);
+          }
+        })
+        .catch(() => {
+          resolve(false);
+        });
+    });
+  }
+  async convert(files: MediaFile[]): Promise<MediaFile[]> {
+    for (const file of files) {
+      await this.checkImage(file.data).then((isValid: boolean) => {
+        if (!isValid) {
+          throw Error("not an image");
+        } else {
+          body.append(file.filepath, file.data);
+        }
+      });
+    }
+
+    const body = new FormData();
+    const url = `${import.meta.env.BASE_URL}${this.path}`;
+    const request = fetch(url, {
+      method: "POST",
+      body,
+    });
+    const response = await (await request).json();
+    if (!this.isMediaResponse(response)) {
+      throw Error("invalid data");
+    }
+    return this.responseToMediaFileArray(response);
+  }
+}

--- a/src/services/converters/MediaConverter.ts
+++ b/src/services/converters/MediaConverter.ts
@@ -1,5 +1,8 @@
 export type MediaResponse = Array<MediaResponseFile>;
-export type MediaResponseFile = { data: string; filepath: string };
+export type MediaResponseFile = {
+  data: string;
+  filepath: string;
+};
 export type MediaFile = { data: Blob; filepath: string };
 
 export default abstract class MediaConverter {
@@ -27,12 +30,13 @@ export default abstract class MediaConverter {
     );
   }
   protected responseToMediaFileArray(
-    response: MediaResponse
+    response: MediaResponse,
+    type: string
   ): Promise<MediaFile[]> {
     return Promise.all<MediaFile>(
       response.map((file: MediaResponseFile): Promise<MediaFile> => {
         return new Promise<MediaFile>((resolve, reject) => {
-          fetch(file.data)
+          fetch(`data:${type};base64,${file.data}`)
             .then((res) => res.blob())
             .then((data) => {
               resolve({ filepath: file.filepath, data });

--- a/src/services/converters/MediaConverter.ts
+++ b/src/services/converters/MediaConverter.ts
@@ -1,0 +1,47 @@
+export type MediaResponse = Array<MediaResponseFile>;
+export type MediaResponseFile = { data: string; filepath: string };
+export type MediaFile = { data: Blob; filepath: string };
+
+export default abstract class MediaConverter {
+  protected path: string;
+  constructor(path: string) {
+    this.path = path;
+  }
+
+  abstract convert(files: MediaFile[]): Promise<MediaFile[]>;
+
+  protected isMediaResponse(response: unknown): response is MediaResponse {
+    return (
+      Array.isArray(response) &&
+      response.length > 0 &&
+      "data" in response[0] &&
+      "filepath" in response[0]
+    );
+  }
+  protected isMediaFile(file: unknown): file is MediaFile {
+    return (
+      typeof file === "object" &&
+      file !== null &&
+      "data" in file &&
+      "filepath" in file
+    );
+  }
+  protected responseToMediaFileArray(
+    response: MediaResponse
+  ): Promise<MediaFile[]> {
+    return Promise.all<MediaFile>(
+      response.map((file: MediaResponseFile): Promise<MediaFile> => {
+        return new Promise<MediaFile>((resolve, reject) => {
+          fetch(file.data)
+            .then((res) => res.blob())
+            .then((data) => {
+              resolve({ filepath: file.filepath, data });
+            })
+            .catch((error) => {
+              reject(error);
+            });
+        });
+      })
+    );
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [react(), tsconfigPaths()],
     define: {
-      BASE_URL: JSON.stringify(env.BASE_URL),
+      "process.env.BASE_URL": JSON.stringify(env.BASE_URL),
     },
   };
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  return {
+    plugins: [react(), tsconfigPaths()],
+    define: {
+      BASE_URL: JSON.stringify(env.BASE_URL),
+    },
+  };
 });


### PR DESCRIPTION
This branch implements the basic MediaConverter classes subtask for Client-Side Optimizations (#4)

- The UI has basic single-file convert functionality for images and fonts, but it should be refined further
  - To convert an image or a font just drag it over or click on the flask
- ImageMediaConverter checks if image is bigger than 1024x1024