### PR TITLE
Fixed too large images triggering "invalid" error

### DIFF
--- a/src/services/converters/ImageMediaConverter.ts
+++ b/src/services/converters/ImageMediaConverter.ts
@@ -2,10 +2,26 @@ import MediaConverter, { MediaFile } from "./MediaConverter";
 
 const MAX_IMAGE_DIM = 1024;
 
+type ImageErrorReason = "invalid" | "too large";
+
+class ImageError extends Error {
+  public readonly reason: ImageErrorReason;
+  __proto__ = Error;
+  constructor(m: ImageErrorReason) {
+    super(m);
+    this.reason = m;
+    Object.setPrototypeOf(this, ImageError.prototype);
+  }
+}
+
 export default class ImageMediaConverter extends MediaConverter {
   async checkImage(file: Blob): Promise<boolean> {
-    const image = await createImageBitmap(file);
-    return image.width <= MAX_IMAGE_DIM && image.height <= MAX_IMAGE_DIM;
+    try {
+      const image = await createImageBitmap(file);
+      return image.width <= MAX_IMAGE_DIM && image.height <= MAX_IMAGE_DIM;
+    } catch (error) {
+      throw new ImageError("invalid");
+    }
   }
   async convert(files: MediaFile[]): Promise<MediaFile[]> {
     const body = new FormData();
@@ -13,12 +29,14 @@ export default class ImageMediaConverter extends MediaConverter {
     for (const file of files) {
       try {
         if (!(await this.checkImage(file.data))) {
-          throw Error(`Image ${file.filepath} is too large!`);
+          throw new ImageError("too large");
         } else {
           body.append(file.filepath, file.data);
         }
       } catch (error) {
-        throw Error(`Image ${file.filepath} is invalid!`);
+        const reason: ImageErrorReason =
+          error instanceof ImageError ? error.reason : "invalid";
+        throw Error(`Image ${file.filepath} is ${reason}!`);
       }
     }
 


### PR DESCRIPTION
This is the prime example of what happens when you fix something based on a review comment and not bother to test it thoroughly. Fixed now, with a nice custom Error class implementation for potential further use