### PR TITLE
[Feature] Add `[build.packaged]`

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import Flask from "@components/Flask";
 import Footer from "@components/Footer";
 import Banner from "@components/Banner";
 
-import { sendContent, BundlerResponse } from "./services/bundler";
+import { prepareContent, BundlerResponse } from "./services/bundler";
 import { Toaster, toast } from "react-hot-toast";
 
 import successSfx from "@assets/sound/success.ogg";
@@ -55,7 +55,7 @@ function App() {
   };
 
   const handleZipUpload = async (archive: File) => {
-    toast.promise(sendContent(archive), {
+    toast.promise(prepareContent(archive), {
       loading: "Uploading..",
       success: handleUploadSuccess,
       error: handleUploadError,

--- a/src/services/bundler.ts
+++ b/src/services/bundler.ts
@@ -96,7 +96,7 @@ async function fetchGameZip(
   return gameZip;
 }
 
-export async function sendContent(archive: File): Promise<BundlerResponse> {
+export async function prepareContent(archive: File): Promise<BundlerResponse> {
   const [zip, config] = await validateZip(archive);
 
   const iconFiles = await findDefinedIcons(config, zip);
@@ -125,12 +125,21 @@ export async function sendContent(archive: File): Promise<BundlerResponse> {
     };
   }
 
+  return await sendContent(bundle, config, iconFiles, gameZips);
+}
+
+async function sendContent(
+  bundle: JSZip,
+  config: ConfigFile,
+  icons: Record<string, Blob>,
+  gameZips: Record<string, JSZip>
+) {
   const body: FormData = new FormData();
   const endpoint = `${import.meta.env.DEV ? process.env.BASE_URL : ""}/compile`;
 
   /* add icons to form data */
-  for (const key in iconFiles) {
-    body.append(`icon-${key}`, iconFiles[key]);
+  for (const key in icons) {
+    body.append(`icon-${key}`, icons[key]);
   }
 
   /* create the URL parameters */

--- a/src/services/bundler.ts
+++ b/src/services/bundler.ts
@@ -110,6 +110,21 @@ export async function sendContent(archive: File): Promise<BundlerResponse> {
   /* resulting bundle */
   const bundle: JSZip = new JSZip();
 
+  if (!config.build.packaged) {
+    for (const key in gameZips) {
+      const keyKey = key as keyof typeof extensions;
+      bundle.file(
+        `${config.metadata.title}.${extensions[keyKey]}`,
+        await gameZips[key].generateAsync({ type: "blob" })
+      );
+    }
+
+    return {
+      message: "Success.",
+      file: bundle.generateAsync({ type: "blob" }),
+    };
+  }
+
   const body: FormData = new FormData();
   const endpoint = `${import.meta.env.DEV ? process.env.BASE_URL : ""}/compile`;
 

--- a/src/services/bundler.ts
+++ b/src/services/bundler.ts
@@ -112,8 +112,9 @@ export async function sendContent(archive: File): Promise<BundlerResponse> {
 
   if (!config.build.packaged) {
     for (const key in gameZips) {
+      const keyKey = key as keyof typeof extensions;
       bundle.file(
-        `${config.metadata.title}-assets.zip`,
+        `${config.metadata.title}-${extensions[keyKey]}-assets.zip`,
         await gameZips[key].generateAsync({ type: "blob" })
       );
     }

--- a/src/services/bundler.ts
+++ b/src/services/bundler.ts
@@ -112,9 +112,8 @@ export async function sendContent(archive: File): Promise<BundlerResponse> {
 
   if (!config.build.packaged) {
     for (const key in gameZips) {
-      const keyKey = key as keyof typeof extensions;
       bundle.file(
-        `${config.metadata.title}.${extensions[keyKey]}`,
+        `${config.metadata.title}-assets.zip`,
         await gameZips[key].generateAsync({ type: "blob" })
       );
     }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -43,6 +43,7 @@ export interface ConfigFile {
   build: {
     targets: string[];
     source: string;
+    packaged?: boolean;
   };
 }
 


### PR DESCRIPTION
This adds a `packaged` option under the `[build]` section. It is optional, but will need to be explicitly set by the user in order to get a properly bundled executable. We could have it set to `true` by default, but I don't know if we want that or not. Thoughts are welcome.

The end result is that when `false`, we return the game assets only (converted or not) for all targets.